### PR TITLE
Fixed sidekiq init script

### DIFF
--- a/examples/etc/init.d/oneacct-export-sidekiq
+++ b/examples/etc/init.d/oneacct-export-sidekiq
@@ -48,13 +48,21 @@ is_running() {
     [ -f "$pid_file" ] && ps `get_pid` > /dev/null 2>&1
 }
 
+create_dir(){
+    mkdir -p "$run_dir"
+    chown "$user:$user" "$run_dir"
+    chmod 750 "$run_dir"
+}
+
 start() {
     if is_running; then
         echo "Already started"
     else
         echo "Starting $name ..."
 
+        create_dir
         cd "$run_dir"
+
         sudo -u "$user" RAILS_ENV=production SSL_CERT_DIR=$SSL_CERT_DIR ONEACCT_EXPORT_LOG_LEVEL=$ONEACCT_EXPORT_LOG_LEVEL $cmd >> "$stdout_log" 2>> "$stderr_log" &
 
         echo $! > "$pid_file"


### PR DESCRIPTION
Directories in /var/run have to be created on start-up.