### PR TITLE
Including the base_id identifier to skip some VMs

### DIFF
--- a/config/conf.yml
+++ b/config/conf.yml
@@ -22,6 +22,7 @@ defaults: &defaults
   xml_rpc:
     secret: oneadmin:opennebula # If not specified looking for secret in ONE_AUTH and ~/.one/one_auth
     endpoint: http://localhost:2633/RPC2 # Defaults to content of ONE_XMLRPC or content of ~/.one/one_endpoint or http://localhost:2633/RPC2
+    base_id: 0 # The base identifier to export accounting. I.e. if you had some other VMs that you do not want to export or if there were more consecutive VMs that are not in the included groups than the num_of_vms_per_file (in that later case, oneacct-export stops exporting
   redis:
     namespace: oneacct_export # Namespace used by redis for sidekiq jobs
     url: redis://localhost:6379 # URL of redis server, defaults to redis://localhost:6379

--- a/lib/one_data_accessor.rb
+++ b/lib/one_data_accessor.rb
@@ -26,7 +26,7 @@ class OneDataAccessor
     @batch_size = Settings.output['num_of_vms_per_file'] ? Settings.output['num_of_vms_per_file'] : 500
     fail ArgumentError, 'Wrong number of vms per file.' unless number?(@batch_size)
     @base_id = Settings.xml_rpc['base_id' ] ? Settings.xml_rpc['base_id' ] : 0
-    fail ArgumentError, 'Wrong base id.' unless is_number?(@base_id)
+    fail ArgumentError, 'Wrong base id.' unless number?(@base_id)
 
     @compatibility_vm_pool = nil
 

--- a/lib/one_data_accessor.rb
+++ b/lib/one_data_accessor.rb
@@ -25,6 +25,8 @@ class OneDataAccessor
 
     @batch_size = Settings.output['num_of_vms_per_file'] ? Settings.output['num_of_vms_per_file'] : 500
     fail ArgumentError, 'Wrong number of vms per file.' unless number?(@batch_size)
+    @base_id = Settings.xml_rpc['base_id' ] ? Settings.xml_rpc['base_id' ] : 0
+    fail ArgumentError, 'Wrong base id.' unless is_number?(@base_id)
 
     @compatibility_vm_pool = nil
 
@@ -148,8 +150,9 @@ class OneDataAccessor
   def load_vm_pool(batch_number)
     fail ArgumentError, "#{batch_number} is not a valid number" unless number?(batch_number)
     @log.debug("Loading vm pool with batch number: #{batch_number}.")
-    from = batch_number * @batch_size
-    to = (batch_number + 1) * @batch_size - 1
+    @log.debug("Base VM identifier: #{@base_id}.")
+    from = @base_id + batch_number * @batch_size
+    to = @base_id + (batch_number + 1) * @batch_size - 1
 
     # if in compatibility mode, whole virtual machine pool has to be loaded for the first time
     if @compatibility


### PR DESCRIPTION
Under some circumstances it is possible that some VMs should not be exported to the accounting system. As an example, in an existing ONE deployment that is now being set under accounting.

The oneacct_export as is has the follwing problem: 

If you have more VMs than the num_of_vms_per_file that do not belong to a group of the exported groups, oneacct_export stops checking for VMs. That happens because function load_vm_pool returns an empty set and the function OneacctExporter.export stops exporting on the empty set.

That may happen because a batch set of VMs does not belong to any of the exported groups. That does not mean that there are not any VM more in the deployment. That only means that there are not any VM that meets the requirements to be exported.

My pull request helps to solve part of this problem, only if there are some of the VMs that were created at the beginning of the ONE deployment. I.e. making tests or just because we are using a recycled ONE deployment.

* The real of the problem needs to be addressed. 